### PR TITLE
Migration mapper 3

### DIFF
--- a/modules/migration_mapper/src/Plugin/DestinationField/EntityReference.php
+++ b/modules/migration_mapper/src/Plugin/DestinationField/EntityReference.php
@@ -16,7 +16,7 @@ use Drupal\migration_mapper\DestinationFieldBase;
  *   fieldTypes = {
  *     "entity_reference"
  *   },
- *   combinePlugin = TRUE,
+ *   combinePlugin = FALSE,
  * )
  */
 class EntityReference extends DestinationFieldBase {

--- a/patches/migration_mapper/migration_mapper_4_entity_generate_not_add.patch
+++ b/patches/migration_mapper/migration_mapper_4_entity_generate_not_add.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/migration_mapper/src/Plugin/DestinationField/EntityReference.php b/modules/migration_mapper/src/Plugin/DestinationField/EntityReference.php
+index 58673a8..4eb7c42 100644
+--- a/modules/migration_mapper/src/Plugin/DestinationField/EntityReference.php
++++ b/modules/migration_mapper/src/Plugin/DestinationField/EntityReference.php
+@@ -16,7 +16,7 @@ use Drupal\migration_mapper\DestinationFieldBase;
+  *   fieldTypes = {
+  *     "entity_reference"
+  *   },
+- *   combinePlugin = TRUE,
++ *   combinePlugin = FALSE,
+  * )
+  */
+ class EntityReference extends DestinationFieldBase {


### PR DESCRIPTION
If we select any entity reference field and add a process plugin to it, then now entity_generate won't be added. If we do not select any process plugin, then it will behave as is and will add the entity generate.

cc @amitgoyal  @pranitjha 